### PR TITLE
Refactoring C# 7 features to be compatible with Unity

### DIFF
--- a/EosSharp/EosSharp/Eos.cs
+++ b/EosSharp/EosSharp/Eos.cs
@@ -20,7 +20,11 @@ namespace EosSharp
         /// <param name="config">Configures client parameters</param>
         public Eos(EosConfigurator config)
         {
-            EosConfig = config ?? throw new ArgumentNullException("config");
+            EosConfig = config;
+            if (EosConfig == null)
+            {
+                throw new ArgumentNullException("config");
+            }
             Api = new EosApi(EosConfig);
             AbiSerializer = new AbiSerializationProvider(Api);
         }

--- a/EosSharp/EosSharp/Helpers/HttpHelper.cs
+++ b/EosSharp/EosSharp/Helpers/HttpHelper.cs
@@ -41,7 +41,8 @@ namespace EosSharp.Helpers
 
             if (!reload)
             {
-                if (ResponseCache.TryGetValue(hashKey, out object value))
+                object value;
+                if (ResponseCache.TryGetValue(hashKey, out value))
                     return (TResponseData)value;
             }
 
@@ -59,7 +60,8 @@ namespace EosSharp.Helpers
 
             if (!reload)
             {
-                if (ResponseCache.TryGetValue(hashKey, out object value))
+                object value;
+                if (ResponseCache.TryGetValue(hashKey, out value))
                     return (TResponseData)value;
             }
 

--- a/EosSharp/EosSharp/Providers/AbiSerializationProvider.cs
+++ b/EosSharp/EosSharp/Providers/AbiSerializationProvider.cs
@@ -441,7 +441,7 @@ namespace EosSharp.Providers
         {
             var ticks = SerializationHelper.DateToTimePoint((DateTime)value);
             WriteUint32(ms, (UInt32)ticks >> 0);
-            WriteUint32(ms, (UInt32)Math.Floor((double)ticks / 0x10000_0000) >> 0);
+            WriteUint32(ms, (UInt32)Math.Floor((double)ticks / 0x100000000) >> 0);
         }
 
         private static void WriteTimePointSec(MemoryStream ms, object value)
@@ -769,7 +769,7 @@ namespace EosSharp.Providers
             var v = (UInt32)ReadVarUint32(data, ref readIndex);
 
             if ((v & 1) != 0)
-                return ((~v) >> 1) | 0x8000_0000;
+                return ((~v) >> 1) | 0x80000000;
             else
                 return v >> 1;
         }
@@ -875,7 +875,7 @@ namespace EosSharp.Providers
         {
             var low = (UInt32)ReadUint32(data, ref readIndex);
             var high = (UInt32)ReadUint32(data, ref readIndex);
-            return SerializationHelper.TimePointToDate((high >> 0) * 0x10000_0000 + (low >> 0));
+            return SerializationHelper.TimePointToDate((high >> 0) * 0x100000000 + (low >> 0));
         }
 
         private static object ReadTimePointSec(byte[] data, ref Int32 readIndex)

--- a/EosSharp/EosSharp/Providers/AbiSerializationProvider.cs
+++ b/EosSharp/EosSharp/Providers/AbiSerializationProvider.cs
@@ -678,7 +678,8 @@ namespace EosSharp.Providers
 
         private TSerializer GetTypeSerializerAndCache<TSerializer>(string type, Dictionary<string, TSerializer> typeSerializers, Abi abi)
         {
-            if (typeSerializers.TryGetValue(type, out TSerializer nativeSerializer))
+            TSerializer nativeSerializer;
+            if (typeSerializers.TryGetValue(type, out nativeSerializer))
             {
                 return nativeSerializer;
             }


### PR DESCRIPTION
Unity does not support C# 7 digit separators.
It also does not support C# 7 throw expressions or out variable declarations, without specifically setting an experimental text file flag to use C# 7, something that would be cumbersome for most Unity users.

Therefore, this pull requests removes all C# 7 features.