### PR TITLE
Changed authority accounts to use permission level

### DIFF
--- a/EosSharp/EosSharp.Core/Api/v1/Definitions/EosApiTypeDef.t4
+++ b/EosSharp/EosSharp.Core/Api/v1/Definitions/EosApiTypeDef.t4
@@ -38,7 +38,7 @@
 			Name = "AuthorityAccount",
 			Fields = new Field[]
             {
-				new Field() { Name = "account", Type = "string" },
+				new Field() { Name = "permission", Type = "PermissionLevel" },
 				new Field() { Name = "weight", Type = "Int32" }
             }
         },

--- a/EosSharp/EosSharp.Core/Api/v1/EosTypes.cs
+++ b/EosSharp/EosSharp.Core/Api/v1/EosTypes.cs
@@ -40,7 +40,7 @@ namespace EosSharp.Core.Api.v1
 	public class AuthorityAccount
     {
 		
-		public string account;
+		public PermissionLevel permission;
 		
 		public Int32 weight;
     }


### PR DESCRIPTION
Fixed the AuthorityAccount structure of to use PermissionLevel instead of string.